### PR TITLE
add styling for edit/create pages

### DIFF
--- a/src/css/style.css
+++ b/src/css/style.css
@@ -1,3 +1,8 @@
+html,
+body {
+  height: 100%;
+}
+
 body {
   margin: 0;
 }
@@ -83,3 +88,101 @@ header h1 {
 header nav {
   display: none;
 }
+
+/*
+ * styling for /e/ pages
+ */
+
+body.edit {
+  display: flex;
+  flex-flow: column;
+  height: 100%;
+}
+
+body.edit article {
+  margin: 1rem 0;
+  flex-grow: 1;
+}
+
+body.edit form {
+  width: 100vw;
+  height: 100%;
+  display: flex;
+  flex-flow: column;
+}
+
+body.edit form * {
+  text-indent: 0;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+
+body.edit form div {
+  padding: 0 2em;
+}
+
+body.edit form div:nth-of-type(1) {
+  display: flex;
+  flex-flow: row;
+}
+
+body.edit form div:nth-of-type(1) p {
+  flex-grow: 1;
+}
+
+body.edit form div:nth-of-type(1) span {
+  display: block;
+  color: #666;
+  font-size: 60%;
+  font-style: italic;
+  float: right;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+body.edit form div:nth-of-type(2) {
+  flex-grow: 1;
+}
+
+body.edit form div:nth-of-type(3) {
+  padding-top: 0.5em;
+  padding-bottom: 0.5em;
+}
+
+body.edit form label {
+  display: block;
+  font-size: 150%;
+  font-weight: bold;
+  font-family: 'Yanone Kaffeesatz', sans-serif;
+}
+
+body.edit form input[type='text'] {
+  display: block;
+  width: 95%;
+  padding: 0.5em 0.25em;
+  font-family: inherit;
+}
+
+body.edit form label[for='username'],
+body.edit form input[name='username'] {
+  margin-left: 5%;
+}
+
+body.edit form textarea {
+  width: 100%;
+  height: 100%;
+  padding: 0.5em 0.25em;
+  font-family: inherit;
+}
+
+body.edit form input[type='submit'],
+body.edit form input[type='reset'] {
+  font-size: 150%;
+  font-family: 'Yanone Kaffeesatz', sans-serif;
+  padding: 0.25em 0.5em;
+  float: right;
+  margin-left: 0.25em;
+  width: 4em;
+}
+

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -45,6 +45,7 @@
 				<input type='submit' value='Save'>
 				<input type='reset' value='Cancel'>
 			</p>
+		</div>
     </form>
     </article>
 </body>

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -19,25 +19,32 @@
         <input name='id' type='hidden' value='<TMPL_VAR NAME=ID ESCAPE=HTML>'>
         <TMPL_IF NAME=BASE>
         <input name='base' type='hidden' value='<TMPL_VAR NAME=BASE ESCAPE=HTML>'>
-        <p>
-            <label for='title'>New title:</label>
-            <input name='title' type='text'
-                   value='<TMPL_VAR NAME=TITLE ESCAPE=HTML>'>
-        </p>
-        <TMPL_ELSE>
-        <p>Title: <TMPL_VAR NAME=TITLE ESCAPE=HTML></p>
-        <input name='title' type='hidden'
-               value='<TMPL_VAR NAME=TITLE ESCAPE=HTML>'>
-        </TMPL_IF>
-        <p>
-            <label for='username'>Name:</label>
-            <input name='username' type='text'
-                   value='<TMPL_VAR NAME=USERNAME ESCAPE=HTML>'>
-            editing from <TMPL_VAR NAME=IP ESCAPE=HTML>
-        </p>
-        <p><textarea rows='50' cols='80'
-                     name='content'><TMPL_VAR NAME=CONTENT></textarea></p>
-        <p><input type='submit' value='Save'></p>
+		<div>
+			<p>
+				<label for='title'>New title:</label>
+				<input name='title' type='text'
+					   value='<TMPL_VAR NAME=TITLE ESCAPE=HTML>'>
+			</p>
+			<TMPL_ELSE>
+			<p>Title: <TMPL_VAR NAME=TITLE ESCAPE=HTML></p>
+			<input name='title' type='hidden'
+				   value='<TMPL_VAR NAME=TITLE ESCAPE=HTML>'>
+			</TMPL_IF>
+			<p>
+				<label for='username'>Name:</label>
+				<input name='username' type='text'
+					   value='<TMPL_VAR NAME=USERNAME ESCAPE=HTML>'>
+				<span>editing from <TMPL_VAR NAME=IP ESCAPE=HTML></span>
+			</p>
+		</div>
+		<div>
+			<textarea name='content'><TMPL_VAR NAME=CONTENT></textarea>
+		</div>
+		<div>
+			<p>
+				<input type='submit' value='Save'>
+				<input type='reset' value='Cancel'>
+			</p>
     </form>
     </article>
 </body>


### PR DESCRIPTION
> using flexboxes, the edit page now adapts to different screen sizes.
> everything will fit on screen and adjust fluidly to changes in
> window size or orientation. this will make editing much nicer, esp.
> on mobile.
> 
> also adds a cancel button to the edit screen which reverts any
> changes made in the current edit.

this is purely structural. it's using all your fonts and colors and spacing.

should look something like this:
![sample of new edit interface](http://i.imgur.com/BQfteag.png)
