### PR TITLE
Support Configurable Language Attribute

### DIFF
--- a/src/M/Render.pm
+++ b/src/M/Render.pm
@@ -32,6 +32,7 @@ sub new {
         q => $q,
         db => $args{database},
         site_root => $args{site_root},
+        language => $args{language},
         timezone => $args{timezone},
         rfc3339formatter => DateTime::Format::RFC3339->new(),
     }, $class);
@@ -52,6 +53,7 @@ sub show_page {
         die_on_bad_params => 0);
     $template->param(TITLE => $title);
     $template->param(SITE_ROOT => $self->{site_root});
+    $template->param(LANGAUGE => $self->{language});
     $template->param(BODY => $body);
     print $self->q->header("text/html; charset=utf-8", $status);
     print $template->output;
@@ -63,6 +65,7 @@ sub four_oh_four {
         filename => 'templates/404.html',
         die_on_bad_params => 0);
     $template->param(SITE_ROOT => $self->{site_root});
+    $template->param(LANGUAGE => $self->{language});
     $template->param(MESSAGE => $message);
     $self->show_page("404 Not Found", "Not found", $template->output);
 }

--- a/src/conf.pl
+++ b/src/conf.pl
@@ -1,3 +1,4 @@
 TIMEZONE => 'EST',
 DATABASE => '/home/protected/books.sqlite3',
 SITE_ROOT => 'http://sleepingcyb.org/books',
+LANGUAGE => 'en',

--- a/src/e.pl
+++ b/src/e.pl
@@ -29,6 +29,7 @@ my $db = M::DB->new($conf{DATABASE});
 my $r = M::Render->new(
     database => $db,
     site_root => $conf{SITE_ROOT},
+    language => $conf{LANGUAGE},
     timezone => $conf{TIMEZONE});
 
 my $slug = substr($r->q->path_info(), 1);

--- a/src/e.pl
+++ b/src/e.pl
@@ -121,6 +121,7 @@ my $template = HTML::Template->new(
 
 $template->param(ID => $id);
 $template->param(SITE_ROOT => $conf{SITE_ROOT});
+$template->param(LANGUAGE => $conf{LANGUAGE});
 $template->param(SLUG => $slug);
 $template->param(ERRORS => \@errors);
 $template->param(TITLE => $title);

--- a/src/e.pl
+++ b/src/e.pl
@@ -108,6 +108,7 @@ if ($r->q->request_method eq 'POST') {
             die_on_bad_params => 0);
         $template->param(TITLE => $title);
         $template->param(SITE_ROOT => $conf{SITE_ROOT});
+        $template->param(LANGUAGE => $conf{LANGUAGE});
 
         print $r->q->header("text/html; charset=utf-8", "200 OK"
             -cookie => $cookie);

--- a/src/f.pl
+++ b/src/f.pl
@@ -28,6 +28,7 @@ my $db = M::DB->new($conf{DATABASE});
 my $r = M::Render->new(
     database => $db,
     site_root => $conf{SITE_ROOT},
+    language => $conf{LANGUAGE},
     timezone => $conf{TIMEZONE});
 
 

--- a/src/f.pl
+++ b/src/f.pl
@@ -41,6 +41,7 @@ sub render_html_feed {
         filename => 'templates/recent.html',
         die_on_bad_params => 0);
     $template->param(SITE_ROOT => $conf{SITE_ROOT});
+    $template->param(LANGUAGE => $conf{LANGUAGE});
     $template->param(EDITS => $edits);
     $template->param(TITLE => $title);
     $template->param(ID => $id);
@@ -55,6 +56,7 @@ sub render_atom_feed {
         filename => 'templates/feed.xml',
         die_on_bad_params => 0);
     $template->param(SITE_ROOT => $conf{SITE_ROOT});
+    $template->param(LANGUAGE => $conf{LANGUAGE});
     $template->param(EDITS => $edits);
     $template->param(TITLE => $title);
     $template->param(ID => $id);

--- a/src/templates/404.html
+++ b/src/templates/404.html
@@ -1,7 +1,7 @@
 <head>
   <TMPL_INCLUDE NAME="headerblock.html">
 </head>
-<body class="err404" lang="en">
+<body class="err404" lang="<TMPL_VAR NAME=LANGUAGE>">
   <header>
     <h1>Not Found</h1>
 	</header>

--- a/src/templates/edit.html
+++ b/src/templates/edit.html
@@ -1,7 +1,7 @@
 <head>
   <TMPL_INCLUDE NAME="headerblock.html">
 </head>
-<body class="edit" lang="en">
+<body class="edit" lang="<TMPL_VAR NAME=LANGUAGE>">
   <header>
     <h1>
       <TMPL_IF NAME=ID>

--- a/src/templates/editok.html
+++ b/src/templates/editok.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="<TMPL_VAR NAME=SITE_ROOT>/css/typography.css" type="text/css" />
     <link rel="stylesheet" href="<TMPL_VAR NAME=SITE_ROOT>/css/style.css" type="text/css" />
   </head>
-  <body class="editok" lang="en">
+  <body class="editok" lang="<TMPL_VAR NAME=LANGUAGE>">
     <header>
       <h1>Your changes have been saved.</h1>
     </header>

--- a/src/templates/entry.html
+++ b/src/templates/entry.html
@@ -5,7 +5,7 @@
   <link rel="alternate" type="application/atom+xml" title="Site edits"
         href="<TMPL_VAR NAME=SITE_ROOT>/f/_all.xml">
 </head>
-<body class="entry" lang="en">
+<body class="entry" lang="<TMPL_VAR NAME=LANGUAGE>">
   <header>
     <h1>
       <a href="<TMPL_VAR NAME=SITE_ROOT>/w/<TMPL_VAR NAME=TITLE ESCAPE=HTML>.links">

--- a/src/templates/feed.xml
+++ b/src/templates/feed.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8" xml:lang="<TMPL_VAR NAME=LANGUAGE />"?>
 <feed xmlns="http://www.w3.org/2005/Atom">
   <id><TMPL_VAR NAME=SITE_ROOT />/f/<TMPL_VAR NAME=ID />.xml</id>
   <title>Recent activity on <TMPL_VAR NAME=TITLE /></title>

--- a/src/templates/links.html
+++ b/src/templates/links.html
@@ -1,7 +1,7 @@
 <head>
   <TMPL_INCLUDE NAME="headerblock.html">
 </head>
-<body class="links" lang="en">
+<body class="links" lang="<TMPL_VAR NAME=LANGUAGE>">
   <header>
     <h1>
       Links to <a href="<TMPL_VAR NAME=SITE_ROOT>/w/<TMPL_VAR NAME=TITLE ESCAPE=HTML>.html">

--- a/src/templates/recent.html
+++ b/src/templates/recent.html
@@ -5,7 +5,7 @@
   <link rel="alternate" type="application/atom+xml" title="Site edits"
         href="<TMPL_VAR NAME=SITE_ROOT>/f/_all.xml">
 </head>
-<body class="recent" lang="en">
+<body class="recent" lang="<TMPL_VAR NAME=LANGUAGE>">
   <header>
     <h1>Recent edits to
       <a href="<TMPL_VAR NAME=SITE_ROOT>/w/<TMPL_VAR NAME=TITLE>.html">

--- a/src/w.pl
+++ b/src/w.pl
@@ -78,6 +78,7 @@ sub show_entry {
             die_on_bad_params => 0);
         $template->param(TITLE => $page->{title});
         $template->param(SITE_ROOT => $conf{SITE_ROOT});
+        $template->param(LANGUAGE => $conf{LANGUAGE});
         $template->param(CONTENT => $r->render_entry($page->{content}));
         $template->param(USERLINK => $r->render_username($page->{editor}));
         $template->param(EDITED => $r->render_time($page->{edited}));

--- a/src/w.pl
+++ b/src/w.pl
@@ -29,6 +29,7 @@ my $db = M::DB->new($conf{DATABASE});
 my $r = M::Render->new(
     database => $db,
     site_root => $conf{SITE_ROOT},
+    language => $conf{LANGUAGE},
     timezone => $conf{TIMEZONE});
 
 

--- a/src/w.pl
+++ b/src/w.pl
@@ -48,6 +48,7 @@ sub ref_list {
             die_on_bad_params => 0);
         $template->param(TITLE => $title);
         $template->param(SITE_ROOT => $conf{SITE_ROOT});
+        $template->param(LANGUAGE => $conf{LANGUAGE});
         $template->param(LINKS => \@links);
         $r->show_page("200 OK", "Links to $title", $template->output);
     } else {


### PR DESCRIPTION
> The language setting for HTML pages (which was added in order to
> help the browser decide where to break long words onto a new line
> in justified text) is now defined in conf.pl.

i'm learning perl!
